### PR TITLE
Feat trimming

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -4,7 +4,13 @@
     "repos": {
         "https://github.com/nf-core/modules.git": {
             "modules": {
-                "nf-core": {}
+                "nf-core": {
+                    "trimmomatic": {
+                        "branch": "master",
+                        "git_sha": "8fc1d24c710ebe1d5de0f2447ec9439fd3d9d66a",
+                        "installed_by": ["modules"]
+                    }
+                }
             }
         }
     }

--- a/modules/local/fastqc/main.nf
+++ b/modules/local/fastqc/main.nf
@@ -6,12 +6,12 @@ process FASTQC {
     tuple val(sample_id), path(reads)
 
     output:
-    path "fastqc_${sample_id}_logs/*"
+    path "${sample_id}_fastqc_logs/*"
 
     script:
     """
-    mkdir fastqc_${sample_id}_logs
-    fastqc -o fastqc_${sample_id}_logs -f fastq -q ${reads[0]}
-    fastqc -o fastqc_${sample_id}_logs -f fastq -q ${reads[1]}
+    mkdir ${sample_id}_fastqc_logs
+    fastqc -o ${sample_id}_fastqc_logs -f fastq -q ${reads[0]}
+    fastqc -o ${sample_id}_fastqc_logs -f fastq -q ${reads[1]}
     """
 }

--- a/modules/local/trimmomatic/main.nf
+++ b/modules/local/trimmomatic/main.nf
@@ -6,19 +6,10 @@ process TRIMMOMATIC {
     tuple val(sample_id), path(reads)
 
     output:
-    // val sample_id
-    // path "fastp_${sample_id}_logs/*"
-    // path "fastp_${sample_id}_trim_R1.fastq.gz"
-    // path "fastp_${sample_id}_trim_R2.fastq.gz"
-    tuple val(sample_id), path("fastp_${sample_id}_logs/*"), path("fastp_${sample_id}_trim_R1.fastq.gz"), path("fastp_${sample_id}_trim_R2.fastq.gz")
+    tuple val(sample_id), path("${sample_id}_trimmomatic.log"), path("${sample_id}_trim_R1.fastq.gz"), path("${sample_id}_trim_R2.fastq.gz")
 
     script:
     """
-    mkdir fastp_${sample_id}_logs
-    touch fastp_${sample_id}_logs/fastp_${sample_id}.html
-    trimmomatic PE -threads 2 -phred33 ${reads[0]} ${reads[1]} fastp_${sample_id}_trim_R1.fastq.gz fastp_${sample_id}_trim_R1_unpaired.fastq.gz fastp_${sample_id}_trim_R2.fastq.gz fastp_${sample_id}_trim_R2_unpaired.fastq.gz ILLUMINACLIP:TruSeq3-PE.fa:2:30:10 LEADING:3 TRAILING:3 SLIDINGWINDOW:4:15 MINLEN:36
+    trimmomatic PE -threads 2 -phred33 ${reads[0]} ${reads[1]} ${sample_id}_trim_R1.fastq.gz ${sample_id}_trim_R1_unpaired.fastq.gz ${sample_id}_trim_R2.fastq.gz ${sample_id}_trim_R2_unpaired.fastq.gz ILLUMINACLIP:TruSeq3-PE.fa:2:30:10 LEADING:3 TRAILING:3 SLIDINGWINDOW:4:15 MINLEN:36 2> ${sample_id}_trimmomatic.log
     """
-    // fastp -i ${reads[0]} -I ${reads[1]} -o fastp_${sample_id}_R1.fastq.gz -O fastp_${sample_id}_R2.fastq.gz -h fastp_${sample_id}.html -j fastp_${sample_id}.json
-    // touch fastp_${sample_id}_trim_R1.fastq.gz
-    // touch fastp_${sample_id}_trim_R2.fastq.gz
 }

--- a/modules/local/trimmomatic/main.nf
+++ b/modules/local/trimmomatic/main.nf
@@ -6,10 +6,22 @@ process TRIMMOMATIC {
     tuple val(sample_id), path(reads)
 
     output:
-    tuple val(sample_id), path("${sample_id}_trimmomatic.log"), path("${sample_id}_trim_R1.fastq.gz"), path("${sample_id}_trim_R2.fastq.gz")
+    tuple   val(sample_id), 
+            path("${sample_id}_trimmomatic.log"), 
+            path("${sample_id}_trim_R1.fastq.gz"), 
+            path("${sample_id}_trim_R2.fastq.gz")
 
     script:
     """
-    trimmomatic PE -threads 2 -phred33 ${reads[0]} ${reads[1]} ${sample_id}_trim_R1.fastq.gz ${sample_id}_trim_R1_unpaired.fastq.gz ${sample_id}_trim_R2.fastq.gz ${sample_id}_trim_R2_unpaired.fastq.gz ILLUMINACLIP:TruSeq3-PE.fa:2:30:10 LEADING:3 TRAILING:3 SLIDINGWINDOW:4:15 MINLEN:36 -summary ${sample_id}_trimmomatic.summary 2> ${sample_id}_trimmomatic.log
+    trimmomatic \\
+        PE \\
+        -threads 2 \\
+        -phred33 \\
+        ${reads[0]} ${reads[1]} \\
+        ${sample_id}_trim_R1.fastq.gz ${sample_id}_trim_R1_unpaired.fastq.gz \\
+        ${sample_id}_trim_R2.fastq.gz ${sample_id}_trim_R2_unpaired.fastq.gz \\
+        ILLUMINACLIP:TruSeq3-PE.fa:2:30:10 LEADING:3 TRAILING:3 SLIDINGWINDOW:4:15 MINLEN:36 \\
+        -summary ${sample_id}_trimmomatic.summary \\
+        2> ${sample_id}_trimmomatic.log
     """
 }

--- a/modules/local/trimmomatic/main.nf
+++ b/modules/local/trimmomatic/main.nf
@@ -10,6 +10,6 @@ process TRIMMOMATIC {
 
     script:
     """
-    trimmomatic PE -threads 2 -phred33 ${reads[0]} ${reads[1]} ${sample_id}_trim_R1.fastq.gz ${sample_id}_trim_R1_unpaired.fastq.gz ${sample_id}_trim_R2.fastq.gz ${sample_id}_trim_R2_unpaired.fastq.gz ILLUMINACLIP:TruSeq3-PE.fa:2:30:10 LEADING:3 TRAILING:3 SLIDINGWINDOW:4:15 MINLEN:36 2> ${sample_id}_trimmomatic.log
+    trimmomatic PE -threads 2 -phred33 ${reads[0]} ${reads[1]} ${sample_id}_trim_R1.fastq.gz ${sample_id}_trim_R1_unpaired.fastq.gz ${sample_id}_trim_R2.fastq.gz ${sample_id}_trim_R2_unpaired.fastq.gz ILLUMINACLIP:TruSeq3-PE.fa:2:30:10 LEADING:3 TRAILING:3 SLIDINGWINDOW:4:15 MINLEN:36 -summary ${sample_id}_trimmomatic.summary 2> ${sample_id}_trimmomatic.log
     """
 }

--- a/modules/local/trimmomatic/main.nf
+++ b/modules/local/trimmomatic/main.nf
@@ -1,0 +1,24 @@
+process TRIMMOMATIC {
+    tag "TRIMMOMATIC on $sample_id"
+    publishDir params.outdir, mode:'copy'
+
+    input:
+    tuple val(sample_id), path(reads)
+
+    output:
+    // val sample_id
+    // path "fastp_${sample_id}_logs/*"
+    // path "fastp_${sample_id}_trim_R1.fastq.gz"
+    // path "fastp_${sample_id}_trim_R2.fastq.gz"
+    tuple val(sample_id), path("fastp_${sample_id}_logs/*"), path("fastp_${sample_id}_trim_R1.fastq.gz"), path("fastp_${sample_id}_trim_R2.fastq.gz")
+
+    script:
+    """
+    mkdir fastp_${sample_id}_logs
+    touch fastp_${sample_id}_logs/fastp_${sample_id}.html
+    trimmomatic PE -threads 2 -phred33 ${reads[0]} ${reads[1]} fastp_${sample_id}_trim_R1.fastq.gz fastp_${sample_id}_trim_R1_unpaired.fastq.gz fastp_${sample_id}_trim_R2.fastq.gz fastp_${sample_id}_trim_R2_unpaired.fastq.gz ILLUMINACLIP:TruSeq3-PE.fa:2:30:10 LEADING:3 TRAILING:3 SLIDINGWINDOW:4:15 MINLEN:36
+    """
+    // fastp -i ${reads[0]} -I ${reads[1]} -o fastp_${sample_id}_R1.fastq.gz -O fastp_${sample_id}_R2.fastq.gz -h fastp_${sample_id}.html -j fastp_${sample_id}.json
+    // touch fastp_${sample_id}_trim_R1.fastq.gz
+    // touch fastp_${sample_id}_trim_R2.fastq.gz
+}

--- a/modules/nf-core/trimmomatic/environment.yml
+++ b/modules/nf-core/trimmomatic/environment.yml
@@ -1,0 +1,6 @@
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - bioconda::trimmomatic=0.39

--- a/modules/nf-core/trimmomatic/main.nf
+++ b/modules/nf-core/trimmomatic/main.nf
@@ -1,0 +1,48 @@
+process TRIMMOMATIC {
+    tag "$meta.id"
+    label 'process_medium'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/trimmomatic:0.39--hdfd78af_2':
+        'biocontainers/trimmomatic:0.39--hdfd78af_2' }"
+
+    input:
+    tuple val(meta), path(reads)
+
+    output:
+    tuple val(meta), path("*.paired.trim*.fastq.gz")   , emit: trimmed_reads
+    tuple val(meta), path("*.unpaired.trim_*.fastq.gz"), optional:true, emit: unpaired_reads
+    tuple val(meta), path("*.log")                     , emit: log
+    tuple val(meta), path("*.summary")                 , emit: summary
+    path "versions.yml"                                , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def trimmed = meta.single_end ? "SE" : "PE"
+    def output = meta.single_end ?
+        "${prefix}.SE.paired.trim.fastq.gz" // HACK to avoid unpaired and paired in the trimmed_reads output
+        : "${prefix}.paired.trim_1.fastq.gz ${prefix}.unpaired.trim_1.fastq.gz ${prefix}.paired.trim_2.fastq.gz ${prefix}.unpaired.trim_2.fastq.gz"
+    // TODO Give better error output
+    def qual_trim = task.ext.args2 ?: ''
+    """
+    trimmomatic \\
+        $trimmed \\
+        -threads $task.cpus \\
+        -trimlog ${prefix}.log \\
+        -summary ${prefix}.summary \\
+        $reads \\
+        $output \\
+        $qual_trim \\
+        $args
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        trimmomatic: \$(trimmomatic -version)
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/trimmomatic/main.nf
+++ b/modules/nf-core/trimmomatic/main.nf
@@ -2,10 +2,10 @@ process TRIMMOMATIC {
     tag "$meta.id"
     label 'process_medium'
 
-    conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/trimmomatic:0.39--hdfd78af_2':
-        'biocontainers/trimmomatic:0.39--hdfd78af_2' }"
+    // conda "${moduleDir}/environment.yml"
+    // container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+    //     'https://depot.galaxyproject.org/singularity/trimmomatic:0.39--hdfd78af_2':
+    //     'biocontainers/trimmomatic:0.39--hdfd78af_2' }"
 
     input:
     tuple val(meta), path(reads)

--- a/modules/nf-core/trimmomatic/meta.yml
+++ b/modules/nf-core/trimmomatic/meta.yml
@@ -1,0 +1,54 @@
+name: "trimmomatic"
+description: Performs quality and adapter trimming on paired end and single end reads
+keywords:
+  - trimming
+  - adapter trimming
+  - quality trimming
+tools:
+  - "trimmomatic":
+      description: "A flexible read trimming tool for Illumina NGS data"
+      homepage: "http://www.usadellab.org/cms/?page=trimmomatic"
+      documentation: "https://github.com/usadellab/Trimmomatic"
+      doi: "10.1093/bioinformatics/btu170"
+      licence: "['GPL v3']"
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - reads:
+      type: file
+      description: |
+        Input FastQ files of size 1 or 2 for single-end and paired-end data, respectively.
+      pattern: "*.fastq.gz"
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - trimmed_reads:
+      type: file
+      description: The trimmed/modified paired end fastq reads
+      pattern: "*.paired.trim*.fastq.gz"
+  - unpaired_reads:
+      type: file
+      description: The trimmed/modified unpaired end fastq reads
+      pattern: "*.unpaired.trim_*.fastq.gz"
+  - log:
+      type: file
+      description: trimmomatic log file
+      pattern: "*.log"
+  - summary:
+      type: file
+      description: trimmomatic summary file of surviving and dropped reads
+      pattern: "*.summary"
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+authors:
+  - "@alyssa-ab"
+maintainers:
+  - "@alyssa-ab"

--- a/modules/nf-core/trimmomatic/tests/main.nf.test
+++ b/modules/nf-core/trimmomatic/tests/main.nf.test
@@ -1,0 +1,95 @@
+nextflow_process {
+
+    name "Test Process TRIMMOMATIC"
+    script "../main.nf"
+    process "TRIMMOMATIC"
+    tag "modules"
+    tag "modules_nfcore"
+    tag "trimmomatic"
+
+    test("Single-Read") {
+        config "./nextflow_SE.config"
+        when {
+            params {
+                outdir   = "$outputDir"
+            }
+            process {
+                """
+                input[0] = [
+                    [ id: 'test', single_end:true ],
+                    [
+                        file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true)
+                    ]
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll (
+                { assert process.success },
+                { assert process.out.trimmed_reads != null },
+                { assert process.out.trimmed_reads.get(0).get(1) ==~ ".*.SE.paired.trim.fastq.gz" },
+                { assert snapshot(process.out.versions).match("versions") },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("Paired-Reads") {
+        config "./nextflow_PE.config"
+        when {
+            params {
+                outdir   = "$outputDir"
+            }
+            process {
+                """
+                input[0] = [
+                    [ id: 'test', single_end:false ],
+                    [
+                        file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true),
+                        file(params.test_data['sarscov2']['illumina']['test_2_fastq_gz'], checkIfExists: true)
+                    ]
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll (
+                { assert process.success },
+                { assert process.out.trimmed_reads != null },
+                { assert process.out.trimmed_reads.get(0).get(1).get(0) ==~ ".*.paired.trim_1.fastq.gz" },
+                { assert process.out.trimmed_reads.get(0).get(1).get(1) ==~ ".*.paired.trim_2.fastq.gz" },
+                { assert snapshot(process.out).match() },
+                { assert snapshot(process.out.versions).match("versions") },
+            )
+        }
+    }
+
+    test("No Adaptors") {
+
+        when {
+            params {
+                outdir   = "$outputDir"
+            }
+            process {
+                """
+                input[0] = [
+                    [ id: 'test', single_end:false ],
+                    [
+                        file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true),
+                        file(params.test_data['sarscov2']['illumina']['test_2_fastq_gz'], checkIfExists: true)
+                    ]
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll (
+                { assert process.failed }
+            )
+        }
+    }
+}

--- a/modules/nf-core/trimmomatic/tests/main.nf.test.snap
+++ b/modules/nf-core/trimmomatic/tests/main.nf.test.snap
@@ -1,0 +1,180 @@
+{
+    "versions": {
+        "content": [
+            [
+                "versions.yml:md5,14413a048f088a147fb04f3d59c6c604"
+            ]
+        ],
+        "timestamp": "2023-10-18T12:15:39.464478"
+    },
+    "Single-Read": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.SE.paired.trim.fastq.gz:md5,089a57f61d7197566b8a3ce71df79113"
+                    ]
+                ],
+                "1": [
+                    
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.log:md5,e4c3f619e9b0e26847f8f3e3d9af319b"
+                    ]
+                ],
+                "3": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.summary:md5,24c973237557a1439c775ca19a5deaa5"
+                    ]
+                ],
+                "4": [
+                    "versions.yml:md5,14413a048f088a147fb04f3d59c6c604"
+                ],
+                "log": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.log:md5,e4c3f619e9b0e26847f8f3e3d9af319b"
+                    ]
+                ],
+                "summary": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.summary:md5,24c973237557a1439c775ca19a5deaa5"
+                    ]
+                ],
+                "trimmed_reads": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.SE.paired.trim.fastq.gz:md5,089a57f61d7197566b8a3ce71df79113"
+                    ]
+                ],
+                "unpaired_reads": [
+                    
+                ],
+                "versions": [
+                    "versions.yml:md5,14413a048f088a147fb04f3d59c6c604"
+                ]
+            }
+        ],
+        "timestamp": "2023-10-18T12:15:39.471788"
+    },
+    "Paired-Reads": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        [
+                            "test.paired.trim_1.fastq.gz:md5,575355b98cb5ef9071fad8014c702f4a",
+                            "test.paired.trim_2.fastq.gz:md5,73fb54874d01b2854640266d12cc534a"
+                        ]
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        [
+                            "test.unpaired.trim_1.fastq.gz:md5,2f7b5a15cc4e73a6fb4af1fa01f575cd",
+                            "test.unpaired.trim_2.fastq.gz:md5,096ad7f876b6b704ef7f9f2c5af3cf74"
+                        ]
+                    ]
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.log:md5,9629761761a34576b3484bf4174f681f"
+                    ]
+                ],
+                "3": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.summary:md5,9698e5e5c060bbe64588998fe35f8d71"
+                    ]
+                ],
+                "4": [
+                    "versions.yml:md5,14413a048f088a147fb04f3d59c6c604"
+                ],
+                "log": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.log:md5,9629761761a34576b3484bf4174f681f"
+                    ]
+                ],
+                "summary": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.summary:md5,9698e5e5c060bbe64588998fe35f8d71"
+                    ]
+                ],
+                "trimmed_reads": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        [
+                            "test.paired.trim_1.fastq.gz:md5,575355b98cb5ef9071fad8014c702f4a",
+                            "test.paired.trim_2.fastq.gz:md5,73fb54874d01b2854640266d12cc534a"
+                        ]
+                    ]
+                ],
+                "unpaired_reads": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        [
+                            "test.unpaired.trim_1.fastq.gz:md5,2f7b5a15cc4e73a6fb4af1fa01f575cd",
+                            "test.unpaired.trim_2.fastq.gz:md5,096ad7f876b6b704ef7f9f2c5af3cf74"
+                        ]
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,14413a048f088a147fb04f3d59c6c604"
+                ]
+            }
+        ],
+        "timestamp": "2023-10-18T12:15:44.677305"
+    }
+}

--- a/modules/nf-core/trimmomatic/tests/nextflow_PE.config
+++ b/modules/nf-core/trimmomatic/tests/nextflow_PE.config
@@ -1,0 +1,6 @@
+process {
+
+    withName: TRIMMOMATIC {
+        ext.args = 'ILLUMINACLIP:TruSeq3-PE.fa:2:30:10 LEADING:3 TRAILING:3 SLIDINGWINDOW:4:15 MINLEN:36'
+    }
+}

--- a/modules/nf-core/trimmomatic/tests/nextflow_SE.config
+++ b/modules/nf-core/trimmomatic/tests/nextflow_SE.config
@@ -1,0 +1,6 @@
+process {
+
+    withName: TRIMMOMATIC {
+        ext.args = 'ILLUMINACLIP:TruSeq3-SE:2:30:10 LEADING:3 TRAILING:3 SLIDINGWINDOW:4:15 MINLEN:36'
+    }
+}

--- a/modules/nf-core/trimmomatic/tests/tags.yml
+++ b/modules/nf-core/trimmomatic/tests/tags.yml
@@ -1,0 +1,2 @@
+trimmomatic:
+  - modules/nf-core/trimmomatic/**

--- a/workflows/nf_bactvar.nf
+++ b/workflows/nf_bactvar.nf
@@ -40,7 +40,6 @@ include { TRIMMOMATIC } from '../modules/local/trimmomatic/main'
 //
 // MODULE: Installed directly from nf-core/modules
 //
-// include { TRIMMOMATIC } from '../modules/nf-core/trimmomatic/main'
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/workflows/nf_bactvar.nf
+++ b/workflows/nf_bactvar.nf
@@ -29,6 +29,7 @@ for (param in checkPathParamList) { if (param) { file(param, checkIfExists: true
 //
 include { FASTQC  } from '../modules/local/fastqc/main'
 include { MULTIQC } from '../modules/local/multiqc/main'
+include { TRIMMOMATIC } from '../modules/local/trimmomatic/main'
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -39,7 +40,7 @@ include { MULTIQC } from '../modules/local/multiqc/main'
 //
 // MODULE: Installed directly from nf-core/modules
 //
-include { TRIMMOMATIC } from '../modules/nf-core/trimmomatic/main'
+// include { TRIMMOMATIC } from '../modules/nf-core/trimmomatic/main'
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -69,6 +70,16 @@ workflow NF_BACTVAR {
     
     fastqc_results_ch
     | MULTIQC
+
+    // Trim reads
+    full_samples_ch
+    .map { sample_id, meta, reads -> tuple(sample_id, reads)}
+    | TRIMMOMATIC
+    | set { trimmed_samples_ch }
+
+    trimmed_samples_ch
+    | map { sample_id, path_log, path_trim_R1, path_trim_R2 -> tuple(sample_id, path_trim_R1, path_trim_R2) }
+    | view
 
 }
 

--- a/workflows/nf_bactvar.nf
+++ b/workflows/nf_bactvar.nf
@@ -39,7 +39,7 @@ include { MULTIQC } from '../modules/local/multiqc/main'
 //
 // MODULE: Installed directly from nf-core/modules
 //
-
+include { TRIMMOMATIC } from '../modules/nf-core/trimmomatic/main'
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This PR focuses on implementing a trimming step to the ``NF_BACTVAR`` workflow. The ``TRIMMOMATIC`` process trims reads via [trimmomatic](http://www.usadellab.org/cms/index.php?page=trimmomatic). The process is modeled after the nf-core ``TRIMMOMATIC`` process, which wasn't used for simplicity. QC steps are also updated to make a single ``MultiQC`` report of both ``fastqc`` logs of raw reads and log files from ``trimmomatic``.